### PR TITLE
docs: Version release plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,16 @@ prove compliance and reproducibility of the core SOFA C functionality.
 
 The package versions correspond to the following releases of the SOFA C Library:
 
-| Package Version | SOFA Release |
-| --------------- | ------------ |
-| v1.0            | 2019-07-22   |
-| v0.1            | 2018-01-30   |
+| Package Version | SOFA Release | build      |
+| :-------------- | :----------- | :--------  |
+| v2.0            | 2023-10-11   | pure Julia |
+| v1.5            | 2023-10-11   | jll        |
+| v1.4            | 2021-05-12   | jll        |
+| v1.3            | 2021-01-25_a | jll        |
+| v1.2            | 2020-07-21   | jll        |
+| v1.1            | 2019-07-22   | jll        |
+| v1.0            | 2019-07-22   | manual     |
+| v0.1            | 2018-01-30   | manual     |
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ prove compliance and reproducibility of the core SOFA C functionality.
 
 ## Package Version <-> SOFA Release Correspondence
 
-The package versions correspond to the following releases of the SOFA C Library:
+The planned package versions below correspond to the following releases of the SOFA C Library:
 
 | Package Version | SOFA Release | build      |
 | :-------------- | :----------- | :--------  |


### PR DESCRIPTION
## Summary

Starting staging area for packaging newer ANSI C SOFA releases + pure Julia impl

Contacted SOFA board to request tarbarlls

Motivation: Maintain a historical reference for users that is accessible via easy jll builds

## 2019 - 2023 Release summary

| SOFA date     | What changed | New routines |
|---------------|---|---|
| 2019-07-22    | (starting point — what `SOFA_jll` 2019.7.22+0 ships) | — |
| 2020-07-21    | Bug fixes only | none |
| 2021-01-25    | Bug and accuracy fixes | none |
| 2021-01-25_a  | Small bug-fix patch on top of 2021-01-25 | none |
| 2021-05-12    | Bug fixes + 3 new routines | `iauAtcc13`, `iauAtccq`, `iauMoon98` |
| 2023-10-11    | Bug fixes only (STARPV/PVSTAR machine-precision tweaks, `IYV` bumped to 2023, comment corrections in A2TF/ATOIQ/C2T06A/FK45Z/FK54Z/HFK5Z/LTPB, `t_atccq` test fix) | none |

The only release with new API surface in this span is **2021-05-12**, which adds three routines. All other intermediate releases are bug fixes only, with no signature changes.

Sources:
- [ERFA README.rst — "Differences from SOFA"](https://github.com/liberfa/erfa/blob/master/README.rst)
- [ERFA commit b2039ecd "Updating to SOFA 20210512"](https://github.com/liberfa/erfa/commit/b2039ecd)
- [SOFA changes page (2023-10-11 release notes)](https://www.iausofa.org/changes)