### PR TITLE
Release v1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SOFA"
 uuid = "ad3d3fd0-b5f2-51ee-b274-8cdbe62317e2"
 authors = ["Duncan Eddy <duncan.eddy@gmail.com>"]
-version = "1.1.1"
+version = "1.2.0"
 
 [workspace]
 projects = ["test", "docs"]
@@ -14,5 +14,5 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 Libdl = "1"
 StaticArrays = "^1.0.1"
-SOFA_jll = "2019.7.22"
+SOFA_jll = "~2020.7.21"
 julia = "1.10.0"

--- a/test/test_sofa.jl
+++ b/test/test_sofa.jl
@@ -2208,7 +2208,7 @@ let
    @test isapprox(za, 0.2921789846651790546e-3, atol=1e-14)
    @test isapprox(zetaa, 0.3178773290332009310e-3, atol=1e-14)
    @test isapprox(thetaa, 0.2650932701657497181e-3, atol=1e-14)
-   @test isapprox(pa, 0.6651637681381016344e-3, atol=1e-14)
+   @test isapprox(pa, 0.6651637681381016288e-3, atol=1e-14)
    @test isapprox(gam, 0.1398077115963754987e-5, atol=1e-14)
    @test isapprox(phi, 0.4090864090837462602, atol=1e-14)
    @test isapprox(psi, 0.6664464807480920325e-3, atol=1e-14)


### PR DESCRIPTION
`changes.lis`:

```
            Updates for SOFA Release 16 : 2020 July 21
            - - - - - - - - - - - - - - - - - - - - - -

Summary of Changes
------------------
The changes fall into the following categories:

1. Correction of a sign in routine P06E.

2. Correction in the ANSI C macro function dnint in the include file
   sofam.h, to improve rounding.

3. Improvements in precision and rounding (see 2 and 3 below).

4. Miscellaneous typographical corrections and improvements to
   various other documents.

ANSI C Library
--------------

1. iauP06e       Correction. The series are taken from Table 1 of
                 Hilton, J. et al., 2006, Celest. Mech. Dyn. Astron.
                 94, 351., and it has been discovered that the one
                 for general precession, p_A, had the wrong sign for
                 the t^5 coefficient. The error in the paper has
                 been corrected in the SOFA code. The correct value
                 is -0.0000000383 arcsec. (Even after five centuries
                 the error would be lower than 250 microarcsec.)

2. sofam.h       Correction to dnint(A).

                 The existing dnint macro could incorrectly round
                 numbers just over -0.5 and just under +0.5 due to
                 the loss of precision when calculating ceil(A-0.5)
                 or floor(A+0.5). A preliminary test for |A|<0.5
                 has been added to ensure that such numbers always
                 round to zero.  As none of the SOFA C functions
                 depend critically on perfect rounding, the change
                 is unlikely to affect user applications noticeably,
                 though critical round-trip tests may see an
                 improvement.

3. iauPb06       Improvements in the method of decomposing the rotation
                 matrix by ensuring that angles near zero are preferred.

4. iauJd2cal     Improvements by ensuring precision is not lost when
   iauJdcalf     splitting date and time.

5. iauDat        Release year updated.

6. t_sofa_c.c    Updated due to the correction in iauP06e.

7. iauA2af       Minor corrections/improvements to the documentation.
   iauA2tf
   iauD2tf
   iauFk524
   iauFw2m
   iauGmst82
   iauTrxp
   iauXys00a
```

`t_sofa_c.c` diff:

```diff
- vvd(pa, 0.6651637681381016344e-3, 1e-14,
+ vvd(pa, 0.6651637681381016288e-3, 1e-14,
```