### PR TITLE
Release v1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SOFA"
 uuid = "ad3d3fd0-b5f2-51ee-b274-8cdbe62317e2"
 authors = ["Duncan Eddy <duncan.eddy@gmail.com>"]
-version = "1.2.0"
+version = "1.3.0"
 
 [workspace]
 projects = ["test", "docs"]
@@ -14,5 +14,5 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 Libdl = "1"
 StaticArrays = "^1.0.1"
-SOFA_jll = "~2020.7.21"
+SOFA_jll = "~2021.1.25"
 julia = "1.10.0"

--- a/test/test_sofa.jl
+++ b/test/test_sofa.jl
@@ -259,13 +259,13 @@ let
     @test isapprox(astrom.bpn[1][3], -0.1312227200895260194e-2, atol=1e-12)
     @test isapprox(astrom.bpn[2][3], 0.2928082217872315680e-4, atol=1e-12)
     @test isapprox(astrom.bpn[3][3], 0.9999991386008323373, atol=1e-12)
-    @test isapprox(astrom.along, -0.5278008060301974337, atol=1e-12)
-    @test isapprox(astrom.xpl, 0.1133427418174939329e-5, atol=1e-17)
-    @test isapprox(astrom.ypl, 0.1453347595745898629e-5, atol=1e-17)
+    @test isapprox(astrom.along, -0.5278008060295995734, atol=1e-12)
+    @test isapprox(astrom.xpl, 0.1133427418130752958e-5, atol=1e-17)
+    @test isapprox(astrom.ypl, 0.1453347595780646207e-5, atol=1e-17)
     @test isapprox(astrom.sphi, -0.9440115679003211329, atol=1e-12)
     @test isapprox(astrom.cphi, 0.3299123514971474711, atol=1e-12)
     @test astrom.diurab == 0.0
-    @test isapprox(astrom.eral, 2.617608903969802566, atol=1e-12)
+    @test isapprox(astrom.eral, 2.617608903970400427, atol=1e-12)
     @test isapprox(astrom.refa, 0.2014187790000000000e-3, atol=1e-15)
     @test isapprox(astrom.refb, -0.2361408310000000000e-6, atol=1e-18)
 end
@@ -308,13 +308,13 @@ let
     @test isapprox(astrom.bpn[1][3], -0.001312227201745553566, atol=1e-12)
     @test isapprox(astrom.bpn[2][3], 0.2928082218847679162e-4, atol=1e-12)
     @test isapprox(astrom.bpn[3][3], 0.9999991386008312212, atol=1e-12)
-    @test isapprox(astrom.along, -0.5278008060301974337, atol=1e-12)
-    @test isapprox(astrom.xpl, 0.1133427418174939329e-5, atol=1e-17)
-    @test isapprox(astrom.ypl, 0.1453347595745898629e-5, atol=1e-17)
+    @test isapprox(astrom.along, -0.5278008060295995733, atol=1e-12)
+    @test isapprox(astrom.xpl, 0.1133427418130752958e-5, atol=1e-17)
+    @test isapprox(astrom.ypl, 0.1453347595780646207e-5, atol=1e-17)
     @test isapprox(astrom.sphi, -0.9440115679003211329, atol=1e-12)
     @test isapprox(astrom.cphi, 0.3299123514971474711, atol=1e-12)
     @test astrom.diurab == 0.0
-    @test isapprox(astrom.eral, 2.617608909189066140, atol=1e-12)
+    @test isapprox(astrom.eral, 2.617608909189664000, atol=1e-12)
     @test isapprox(astrom.refa, 0.2014187785940396921e-3, atol=1e-15)
     @test isapprox(astrom.refb, -0.2361408314943696227e-6, atol=1e-18)
     @test isapprox(eo, -0.003020548354802412839, atol=1e-14)
@@ -430,13 +430,13 @@ let
 
     astrom = iauApio(sp, theta, elong, phi, hm, xp, yp, refa, refb)
 
-    @test isapprox(astrom.along, -0.5278008060301974337, atol=1e-12)
-    @test isapprox(astrom.xpl, 0.1133427418174939329e-5, atol=1e-17)
-    @test isapprox(astrom.ypl, 0.1453347595745898629e-5, atol=1e-17)
+    @test isapprox(astrom.along, -0.5278008060295995734, atol=1e-12)
+    @test isapprox(astrom.xpl, 0.1133427418130752958e-5, atol=1e-17)
+    @test isapprox(astrom.ypl, 0.1453347595780646207e-5, atol=1e-17)
     @test isapprox(astrom.sphi, -0.9440115679003211329, atol=1e-12)
     @test isapprox(astrom.cphi, 0.3299123514971474711, atol=1e-12)
     @test isapprox(astrom.diurab, 0.5135843661699913529e-6, atol=1e-12)
-    @test isapprox(astrom.eral, 2.617608903969802566, atol=1e-12)
+    @test isapprox(astrom.eral, 2.617608903970400427, atol=1e-12)
     @test isapprox(astrom.refa, 0.2014187790000000000e-3, atol=1e-15)
     @test isapprox(astrom.refb, -0.2361408310000000000e-6, atol=1e-18)
 end
@@ -458,13 +458,13 @@ let
     j, astrom = iauApio13(utc1, utc2, dut1, elong, phi, hm, xp, yp,
                     phpa, tc, rh, wl)
 
-    @test isapprox(astrom.along, -0.5278008060301974337, atol=1e-12)
-    @test isapprox(astrom.xpl, 0.1133427418174939329e-5, atol=1e-17)
-    @test isapprox(astrom.ypl, 0.1453347595745898629e-5, atol=1e-17)
+    @test isapprox(astrom.along, -0.5278008060295995733, atol=1e-12)
+    @test isapprox(astrom.xpl, 0.1133427418130752958e-5, atol=1e-17)
+    @test isapprox(astrom.ypl, 0.1453347595780646207e-5, atol=1e-17)
     @test isapprox(astrom.sphi, -0.9440115679003211329, atol=1e-12)
     @test isapprox(astrom.cphi, 0.3299123514971474711, atol=1e-12)
     @test isapprox(astrom.diurab, 0.5135843661699913529e-6, atol=1e-12)
-    @test isapprox(astrom.eral, 2.617608909189066140, atol=1e-12)
+    @test isapprox(astrom.eral, 2.617608909189664000, atol=1e-12)
     @test isapprox(astrom.refa, 0.2014187785940396921e-3, atol=1e-15)
     @test isapprox(astrom.refb, -0.2361408314943696227e-6, atol=1e-18)
 end
@@ -573,11 +573,11 @@ let
                     utc1, utc2, dut1, elong, phi, hm, xp, yp,
                     phpa, tc, rh, wl)
 
-    @test isapprox(aob, 0.09251774485385390973, atol=1e-12)
-    @test isapprox(zob, 1.407661405256671703, atol=1e-12)
-    @test isapprox(hob, -0.09265154431430045141, atol=1e-12)
-    @test isapprox(dob, 0.1716626560074556029, atol=1e-12)
-    @test isapprox(rob, 2.710260453503366591, atol=1e-12)
+    @test isapprox(aob, 0.9251774485485515207e-1, atol=1e-12)
+    @test isapprox(zob, 1.407661405256499357, atol=1e-12)
+    @test isapprox(hob, -0.9265154431529724692e-1, atol=1e-12)
+    @test isapprox(dob, 0.1716626560072526200, atol=1e-12)
+    @test isapprox(rob, 2.710260453504961012, atol=1e-12)
     @test isapprox(eo, -0.003020548354802412839, atol=1e-14)
     @test j == 0
 end
@@ -653,11 +653,11 @@ let
     j, aob, zob, hob, dob, rob = iauAtio13(ri, di, utc1, utc2, dut1, elong, phi, hm,
                     xp, yp, phpa, tc, rh, wl)
 
-    @test isapprox(aob, 0.09233952224794989993, atol=1e-12)
-    @test isapprox(zob, 1.407758704513722461, atol=1e-12)
-    @test isapprox(hob, -0.09247619879782006106, atol=1e-12)
-    @test isapprox(dob, 0.1717653435758265198, atol=1e-12)
-    @test isapprox(rob, 2.710085107986886201, atol=1e-12)
+    @test isapprox(aob, 0.9233952224895122499e-1, atol=1e-12)
+    @test isapprox(zob, 1.407758704513549991, atol=1e-12)
+    @test isapprox(hob, -0.9247619879881698140e-1, atol=1e-12)
+    @test isapprox(dob, 0.1717653435756234676, atol=1e-12)
+    @test isapprox(rob, 2.710085107988480746, atol=1e-12)
     @test j == 0
 end
 
@@ -682,11 +682,11 @@ let
 
     aob, zob, hob, dob, rob = iauAtioq(ri, di, astrom)
 
-    @test isapprox(aob, 0.09233952224794989993, atol=1e-12)
-    @test isapprox(zob, 1.407758704513722461, atol=1e-12)
-    @test isapprox(hob, -0.09247619879782006106, atol=1e-12)
-    @test isapprox(dob, 0.1717653435758265198, atol=1e-12)
-    @test isapprox(rob, 2.710085107986886201, atol=1e-12)
+    @test isapprox(aob, 0.9233952224895122499e-1, atol=1e-12)
+    @test isapprox(zob, 1.407758704513549991, atol=1e-12)
+    @test isapprox(hob, -0.9247619879881698140e-1, atol=1e-12)
+    @test isapprox(dob, 0.1717653435756234676, atol=1e-12)
+    @test isapprox(rob, 2.710085107988480746, atol=1e-12)
 end
 
 let
@@ -707,24 +707,24 @@ let
     ob2 = 0.1717653435758265198
     j, rc, dc = iauAtoc13('R', ob1, ob2, utc1, utc2, dut1,
                     elong, phi, hm, xp, yp, phpa, tc, rh, wl)
-    @test isapprox(rc, 2.709956744660731630, atol=1e-12)
-    @test isapprox(dc, 0.1741696500896438967, atol=1e-12)
+    @test isapprox(rc, 2.709956744659136129, atol=1e-12)
+    @test isapprox(dc, 0.1741696500898471362, atol=1e-12)
     @test j == 0
 
     ob1 = -0.09247619879782006106
     ob2 = 0.1717653435758265198
     j, rc, dc = iauAtoc13('H', ob1, ob2, utc1, utc2, dut1,
                     elong, phi, hm, xp, yp, phpa, tc, rh, wl)
-    @test isapprox(rc, 2.709956744660731630, atol=1e-12)
-    @test isapprox(dc, 0.1741696500896438967, atol=1e-12)
+    @test isapprox(rc, 2.709956744659734086, atol=1e-12)
+    @test isapprox(dc, 0.1741696500898471362, atol=1e-12)
     @test j == 0
 
     ob1 = 0.09233952224794989993
     ob2 = 1.407758704513722461
     j, rc, dc = iauAtoc13('A', ob1, ob2, utc1, utc2, dut1,
                     elong, phi, hm, xp, yp, phpa, tc, rh, wl)
-    @test isapprox(rc, 2.709956744660731630, atol=1e-12)
-    @test isapprox(dc, 0.1741696500896438970, atol=1e-12)
+    @test isapprox(rc, 2.709956744659734086, atol=1e-12)
+    @test isapprox(dc, 0.1741696500898471366, atol=1e-12)
     @test j == 0 
 end
 
@@ -746,24 +746,24 @@ let
     ob2 = 0.1717653435758265198
     j, ri, di = iauAtoi13('R', ob1, ob2, utc1, utc2, dut1,
                     elong, phi, hm, xp, yp, phpa, tc, rh, wl)
-    @test isapprox(ri, 2.710121574449135955, atol=1e-12)
-    @test isapprox(di, 0.1729371839114567725, atol=1e-12)
+    @test isapprox(ri, 2.710121574447540810, atol=1e-12)
+    @test isapprox(di, 0.1729371839116608778, atol=1e-12)
     @test j == 0
 
     ob1 = -0.09247619879782006106
     ob2 = 0.1717653435758265198
     j, ri, di = iauAtoi13('H', ob1, ob2, utc1, utc2, dut1,
                     elong, phi, hm, xp, yp, phpa, tc, rh, wl)
-    @test isapprox(ri, 2.710121574449135955, atol=1e-12)
-    @test isapprox(di, 0.1729371839114567725, atol=1e-12)
+    @test isapprox(ri, 2.710121574448138676, atol=1e-12)
+    @test isapprox(di, 0.1729371839116608778, atol=1e-12)
     @test j == 0
 
     ob1 = 0.09233952224794989993
     ob2 = 1.407758704513722461
     j, ri, di = iauAtoi13('A', ob1, ob2, utc1, utc2, dut1,
                     elong, phi, hm, xp, yp, phpa, tc, rh, wl)
-    @test isapprox(ri, 2.710121574449135955, atol=1e-12)
-    @test isapprox(di, 0.1729371839114567728, atol=1e-12)
+    @test isapprox(ri, 2.710121574448138676, atol=1e-12)
+    @test isapprox(di, 0.1729371839116608781, atol=1e-12)
     @test j == 0
 end
 
@@ -786,20 +786,20 @@ let
     ob1 = 2.710085107986886201
     ob2 = 0.1717653435758265198
     ri, di = iauAtoiq('R', ob1, ob2, astrom)
-    @test isapprox(ri, 2.710121574449135955, atol=1e-12)
-    @test isapprox(di, 0.1729371839114567725, atol=1e-12)
+    @test isapprox(ri, 2.710121574447540810, atol=1e-12)
+    @test isapprox(di, 0.17293718391166087785, atol=1e-12)
 
     ob1 = -0.09247619879782006106
     ob2 = 0.1717653435758265198
     ri, di = iauAtoiq('H', ob1, ob2, astrom)
-    @test isapprox(ri, 2.710121574449135955, atol=1e-12)
-    @test isapprox(di, 0.1729371839114567725, atol=1e-12)
+    @test isapprox(ri, 2.710121574448138676, atol=1e-12)
+    @test isapprox(di, 0.1729371839116608778, atol=1e-12)
 
     ob1 = 0.09233952224794989993
     ob2 = 1.407758704513722461
     ri, di = iauAtoiq('A', ob1, ob2, astrom)
-    @test isapprox(ri, 2.710121574449135955, atol=1e-12)
-    @test isapprox(di, 0.1729371839114567728, atol=1e-12)
+    @test isapprox(ri, 2.710121574448138676, atol=1e-12)
+    @test isapprox(di, 0.1729371839116608781, atol=1e-12)
 end
 
 let
@@ -1544,7 +1544,7 @@ let
 
     @test isapprox(rh, 1.767794226299947632, atol=1e-14)
     @test isapprox(dh,  -0.2917516070530391757, atol=1e-14)
-    @test isapprox(drh, -0.19618741256057224e-6,atol=1e-19)
+    @test isapprox(drh, -0.1961874125605721270e-6,atol=1e-19)
     @test isapprox(ddh, -0.58459905176693911e-5, atol=1e-19)
     @test isapprox(pxh,  0.37921, atol=1e-14)
     @test isapprox(rvh, -7.6000000940000254, atol=1e-11)
@@ -3040,9 +3040,9 @@ let
 
     upv = iauPvu(2920.0, pv)
 
-    @test isapprox(upv[1, 1], 126656.7598605317105, atol=1e-12)
-    @test isapprox(upv[1, 2], 2118.531271155726332, atol=1e-12)
-    @test isapprox(upv[1, 3], -245216.5048590656190, atol=1e-12)
+    @test isapprox(upv[1, 1], 126656.7598605317105, atol=1e-6)
+    @test isapprox(upv[1, 2], 2118.531271155726332, atol=1e-8)
+    @test isapprox(upv[1, 3], -245216.5048590656190, atol=1e-6)
 
     @test isapprox(upv[2, 1], -0.4051854035740713039e-2, atol=1e-12)
     @test isapprox(upv[2, 2], -0.6253919754866175788e-2, atol=1e-12)
@@ -3055,9 +3055,9 @@ let
 
     p = iauPvup(2920.0, pv)
 
-    @test isapprox(p[1],  126656.7598605317105,   atol=1e-12)
-    @test isapprox(p[2],    2118.531271155726332, atol=1e-12)
-    @test isapprox(p[3], -245216.5048590656190,   atol=1e-12)
+    @test isapprox(p[1],  126656.7598605317105,   atol=1e-6)
+    @test isapprox(p[2],    2118.531271155726332, atol=1e-8)
+    @test isapprox(p[3], -245216.5048590656190,   atol=1e-6)
 end
 
 let


### PR DESCRIPTION
<details><summary><code>changes.lis</code></summary>

```
            Updates for SOFA Release 17 : 2021 January 25
            - - - - - - - - - - - - - - - - - - - - - - -

Summary of Changes
------------------
The changes fall into the following categories:

(1) Extra defensive precautions when computing atmospheric refraction
    at low altitudes.

(2) Application of polar motion handling changed to rigorous. 
    These improvements may result in differences which will be less
    than 1 mu arcsecond (0.000 001 arc seconds).

(3) Expanded documentation, including a new cookbook for the SOFA
    Vector Matrix Library.

(4) Typographical and other minor corrections.

(5) Changes to the test program.

ANSI C Library
--------------

(1) iauAtoiq    Include a limit in altitude (about 3 degrees) below
                which atmospheric refraction is held constant, for
                defense and to make it consistent with iauAtioq.

(2) iauAtioq    Application of polar motion calculation made rigorous 
    iauAtoiq    for canonical consistency.
    iauApco
    iauApio 

(3) The updates in the following functions were documentation corrections:

    iauEe00b    IERS Conventions reference updated to (2003)
    iaugst00b   IERS Conventions reference updated to (2003)
    iauPmat06   IAU reference added
    iauPnm06a   Variable renamed to follow SOFA nomenclature
    iauTrxpv    Action corrected to R^T * PV together with additional note

(4) The updates in the following functions are documentation improvements
    and typographical corrections:

    iauAtciqn  iauAticqn
    iauBi00
    iauC2i00a  iauC2t00a  iauC2t00b  iauC2t06a  iauC2tpe  iauC2txy
    iauEo06a   iauEors
    iauFaom03  iauFk45z   iauFk54z  iauFw2m
    iauGmst00  iauGst00a  iauGst06  iauGst06a  iauGst94
    iauJd2cal  iauJdcalf
    iauNum00a
    iauPmat00  iauPn00a  iauPn00b  iauPn06  iauPnm00a  iauPnm00b
               iauPnm80  iauPom00
    iauRefco   iauRv2m   iauRxpv
    iauS00     iauSxpv
    iautcgtt
    iauUt1utc
    iauXys00b  iauXys06a
    iauZp      iauZpv

(5) Test program t_sofa_c.c was updated due to items (1) and (2) above.

            Updates for SOFA Release 17a : 2021 February
            - - - - - - - - - - - - - - - - - - - - - - -

Summary of Change
-----------------

The change for this minor release (17a) relates to dealing with leap 
seconds during the period 1960 and 1971.

Between the introduction of UTC at the start of 1960 and the first
leap second at the end of 1971 there were a series of small offsets
and rate changes with respect to TAI.  The SOFA routine D2DTF takes
these into account, but a shortcoming in the algorithm meant that
under certain conditions a leap second could be flagged even though
none had occurred.  

Such cases were extremely rare, and moreover depended to some extent 
on compiler behaviour, affecting rounding.

SOFA is grateful to the Astropy group for reporting an instance of
this bug, which has been corrected.

ANSI C:
-------

iauD2dtf       Format for output a 2-part Julian Date (or in the case 
               of UTC a quasi-JD form that includes special provision 
               for leap seconds).
```

</details>


<details><summary><code>t_sofa_c.c</code> diff</summary>

```diff
--- sofa_c-20200721/sofa/20200721/c/src/t_sofa_c.c	2020-07-24 14:21:30.000000000 -0700
+++ sofa_c-20210125_a/sofa/20210125_a/c/src/t_sofa_c.c	2021-02-23 16:21:36.000000000 -0800
@@ -17,11 +17,11 @@
 **
 **  All messages go to stdout.
 **
-**  This revision:  2020 May 30
+**  This revision:  2021 January 5
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2021-01-25
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2021 IAU SOFA Board.  See notes at end.
 */
 
 static void viv(int ival, int ivalok,
@@ -607,7 +607,7 @@
 **
 **  Called:  iauApco, vvd
 **
-**  This revision:  2017 March 15
+**  This revision:  2021 January 5
 */
 {
    double date1, date2, ebpv[2][3], ehp[3], x, y, s,
@@ -685,11 +685,11 @@
                          "iauApco", "bpn(2,3)", status);
    vvd(astrom.bpn[2][2], 0.9999991386008323373, 1e-12,
                          "iauApco", "bpn(3,3)", status);
-   vvd(astrom.along, -0.5278008060301974337, 1e-12,
+   vvd(astrom.along, -0.5278008060295995734, 1e-12,
                      "iauApco", "along", status);
-   vvd(astrom.xpl, 0.1133427418174939329e-5, 1e-17,
+   vvd(astrom.xpl, 0.1133427418130752958e-5, 1e-17,
                    "iauApco", "xpl", status);
-   vvd(astrom.ypl, 0.1453347595745898629e-5, 1e-17,
+   vvd(astrom.ypl, 0.1453347595780646207e-5, 1e-17,
                    "iauApco", "ypl", status);
    vvd(astrom.sphi, -0.9440115679003211329, 1e-12,
                     "iauApco", "sphi", status);
@@ -697,7 +697,7 @@
                     "iauApco", "cphi", status);
    vvd(astrom.diurab, 0, 0,
                       "iauApco", "diurab", status);
-   vvd(astrom.eral, 2.617608903969802566, 1e-12,
+   vvd(astrom.eral, 2.617608903970400427, 1e-12,
                     "iauApco", "eral", status);
    vvd(astrom.refa, 0.2014187790000000000e-3, 1e-15,
                     "iauApco", "refa", status);
@@ -719,7 +719,7 @@
 **
 **  Called:  iauApco13, vvd, viv
 **
-**  This revision:  2017 March 15
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -786,11 +786,11 @@
                          "iauApco13", "bpn(2,3)", status);
    vvd(astrom.bpn[2][2], 0.9999991386008312212, 1e-12,
                          "iauApco13", "bpn(3,3)", status);
-   vvd(astrom.along, -0.5278008060301974337, 1e-12,
+   vvd(astrom.along, -0.5278008060295995733, 1e-12,
                      "iauApco13", "along", status);
-   vvd(astrom.xpl, 0.1133427418174939329e-5, 1e-17,
+   vvd(astrom.xpl, 0.1133427418130752958e-5, 1e-17,
                    "iauApco13", "xpl", status);
-   vvd(astrom.ypl, 0.1453347595745898629e-5, 1e-17,
+   vvd(astrom.ypl, 0.1453347595780646207e-5, 1e-17,
                    "iauApco13", "ypl", status);
    vvd(astrom.sphi, -0.9440115679003211329, 1e-12,
                     "iauApco13", "sphi", status);
@@ -798,7 +798,7 @@
                     "iauApco13", "cphi", status);
    vvd(astrom.diurab, 0, 0,
                       "iauApco13", "diurab", status);
-   vvd(astrom.eral, 2.617608909189066140, 1e-12,
+   vvd(astrom.eral, 2.617608909189664000, 1e-12,
                     "iauApco13", "eral", status);
    vvd(astrom.refa, 0.2014187785940396921e-3, 1e-15,
                     "iauApco13", "refa", status);
@@ -1045,7 +1045,7 @@
 **
 **  Called:  iauApio, vvd
 **
-**  This revision:  2013 October 3
+**  This revision:  2021 January 5
 */
 {
    double sp, theta, elong, phi, hm, xp, yp, refa, refb;
@@ -1064,11 +1064,11 @@
 
    iauApio(sp, theta, elong, phi, hm, xp, yp, refa, refb, &astrom);
 
-   vvd(astrom.along, -0.5278008060301974337, 1e-12,
+   vvd(astrom.along, -0.5278008060295995734, 1e-12,
                      "iauApio", "along", status);
-   vvd(astrom.xpl, 0.1133427418174939329e-5, 1e-17,
+   vvd(astrom.xpl, 0.1133427418130752958e-5, 1e-17,
                    "iauApio", "xpl", status);
-   vvd(astrom.ypl, 0.1453347595745898629e-5, 1e-17,
+   vvd(astrom.ypl, 0.1453347595780646207e-5, 1e-17,
                    "iauApio", "ypl", status);
    vvd(astrom.sphi, -0.9440115679003211329, 1e-12,
                     "iauApio", "sphi", status);
@@ -1076,7 +1076,7 @@
                     "iauApio", "cphi", status);
    vvd(astrom.diurab, 0.5135843661699913529e-6, 1e-12,
                       "iauApio", "diurab", status);
-   vvd(astrom.eral, 2.617608903969802566, 1e-12,
+   vvd(astrom.eral, 2.617608903970400427, 1e-12,
                     "iauApio", "eral", status);
    vvd(astrom.refa, 0.2014187790000000000e-3, 1e-15,
                     "iauApio", "refa", status);
@@ -1098,7 +1098,7 @@
 **
 **  Called:  iauApio13, vvd, viv
 **
-**  This revision:  2013 October 4
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl;
@@ -1122,11 +1122,11 @@
    j = iauApio13(utc1, utc2, dut1, elong, phi, hm, xp, yp,
                  phpa, tc, rh, wl, &astrom);
 
-   vvd(astrom.along, -0.5278008060301974337, 1e-12,
+   vvd(astrom.along, -0.5278008060295995733, 1e-12,
                      "iauApio13", "along", status);
-   vvd(astrom.xpl, 0.1133427418174939329e-5, 1e-17,
+   vvd(astrom.xpl, 0.1133427418130752958e-5, 1e-17,
                    "iauApio13", "xpl", status);
-   vvd(astrom.ypl, 0.1453347595745898629e-5, 1e-17,
+   vvd(astrom.ypl, 0.1453347595780646207e-5, 1e-17,
                    "iauApio13", "ypl", status);
    vvd(astrom.sphi, -0.9440115679003211329, 1e-12,
                     "iauApio13", "sphi", status);
@@ -1134,7 +1134,7 @@
                     "iauApio13", "cphi", status);
    vvd(astrom.diurab, 0.5135843661699913529e-6, 1e-12,
                       "iauApio13", "diurab", status);
-   vvd(astrom.eral, 2.617608909189066140, 1e-12,
+   vvd(astrom.eral, 2.617608909189664000, 1e-12,
                     "iauApio13", "eral", status);
    vvd(astrom.refa, 0.2014187785940396921e-3, 1e-15,
                     "iauApio13", "refa", status);
@@ -1326,7 +1326,7 @@
 **
 **  Called:  iauAtco13, vvd, viv
 **
-**  This revision:  2017 March 15
+**  This revision:  2021 January 5
 */
 {
    double rc, dc, pr, pd, px, rv, utc1, utc2, dut1,
@@ -1359,11 +1359,11 @@
                  phpa, tc, rh, wl,
                  &aob, &zob, &hob, &dob, &rob, &eo);
 
-   vvd(aob, 0.09251774485385390973, 1e-12, "iauAtco13", "aob", status);
-   vvd(zob, 1.407661405256671703, 1e-12, "iauAtco13", "zob", status);
-   vvd(hob, -0.09265154431430045141, 1e-12, "iauAtco13", "hob", status);
-   vvd(dob, 0.1716626560074556029, 1e-12, "iauAtco13", "dob", status);
-   vvd(rob, 2.710260453503366591, 1e-12, "iauAtco13", "rob", status);
+   vvd(aob, 0.9251774485485515207e-1, 1e-12, "iauAtco13", "aob", status);
+   vvd(zob, 1.407661405256499357, 1e-12, "iauAtco13", "zob", status);
+   vvd(hob, -0.9265154431529724692e-1, 1e-12, "iauAtco13", "hob", status);
+   vvd(dob, 0.1716626560072526200, 1e-12, "iauAtco13", "dob", status);
+   vvd(rob, 2.710260453504961012, 1e-12, "iauAtco13", "rob", status);
    vvd(eo, -0.003020548354802412839, 1e-14, "iauAtco13", "eo", status);
    viv(j, 0, "iauAtco13", "j", status);
 
@@ -1505,7 +1505,7 @@
 **
 **  Called:  iauAtio13, vvd, viv
 **
-**  This revision:  2013 October 3
+**  This revision:  2021 January 5
 */
 {
    double ri, di, utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -1532,11 +1532,11 @@
                  xp, yp, phpa, tc, rh, wl,
                  &aob, &zob, &hob, &dob, &rob);
 
-   vvd(aob, 0.09233952224794989993, 1e-12, "iauAtio13", "aob", status);
-   vvd(zob, 1.407758704513722461, 1e-12, "iauAtio13", "zob", status);
-   vvd(hob, -0.09247619879782006106, 1e-12, "iauAtio13", "hob", status);
-   vvd(dob, 0.1717653435758265198, 1e-12, "iauAtio13", "dob", status);
-   vvd(rob, 2.710085107986886201, 1e-12, "iauAtio13", "rob", status);
+   vvd(aob, 0.9233952224895122499e-1, 1e-12, "iauAtio13", "aob", status);
+   vvd(zob, 1.407758704513549991, 1e-12, "iauAtio13", "zob", status);
+   vvd(hob, -0.9247619879881698140e-1, 1e-12, "iauAtio13", "hob", status);
+   vvd(dob, 0.1717653435756234676, 1e-12, "iauAtio13", "dob", status);
+   vvd(rob, 2.710085107988480746, 1e-12, "iauAtio13", "rob", status);
    viv(j, 0, "iauAtio13", "j", status);
 
 }
@@ -1554,7 +1554,7 @@
 **
 **  Called:  iauApio13, iauAtioq, vvd, viv
 **
-**  This revision:  2013 October 4
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -1581,11 +1581,11 @@
 
    iauAtioq(ri, di, &astrom, &aob, &zob, &hob, &dob, &rob);
 
-   vvd(aob, 0.09233952224794989993, 1e-12, "iauAtioq", "aob", status);
-   vvd(zob, 1.407758704513722461, 1e-12, "iauAtioq", "zob", status);
-   vvd(hob, -0.09247619879782006106, 1e-12, "iauAtioq", "hob", status);
-   vvd(dob, 0.1717653435758265198, 1e-12, "iauAtioq", "dob", status);
-   vvd(rob, 2.710085107986886201, 1e-12, "iauAtioq", "rob", status);
+   vvd(aob, 0.9233952224895122499e-1, 1e-12, "iauAtioq", "aob", status);
+   vvd(zob, 1.407758704513549991, 1e-12, "iauAtioq", "zob", status);
+   vvd(hob, -0.9247619879881698140e-1, 1e-12, "iauAtioq", "hob", status);
+   vvd(dob, 0.1717653435756234676, 1e-12, "iauAtioq", "dob", status);
+   vvd(rob, 2.710085107988480746, 1e-12, "iauAtioq", "rob", status);
 
 }
 
@@ -1602,7 +1602,7 @@
 **
 **  Called:  iauAtoc13, vvd, viv
 **
-**  This revision:  2017 March 15
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1,
@@ -1629,8 +1629,8 @@
    j = iauAtoc13 ( "R", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &rc, &dc);
-   vvd(rc, 2.709956744660731630, 1e-12, "iauAtoc13", "R/rc", status);
-   vvd(dc, 0.1741696500896438967, 1e-12, "iauAtoc13", "R/dc", status);
+   vvd(rc, 2.709956744659136129, 1e-12, "iauAtoc13", "R/rc", status);
+   vvd(dc, 0.1741696500898471362, 1e-12, "iauAtoc13", "R/dc", status);
    viv(j, 0, "iauAtoc13", "R/j", status);
 
    ob1 = -0.09247619879782006106;
@@ -1638,8 +1638,8 @@
    j = iauAtoc13 ( "H", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &rc, &dc);
-   vvd(rc, 2.709956744660731630, 1e-12, "iauAtoc13", "H/rc", status);
-   vvd(dc, 0.1741696500896438967, 1e-12, "iauAtoc13", "H/dc", status);
+   vvd(rc, 2.709956744659734086, 1e-12, "iauAtoc13", "H/rc", status);
+   vvd(dc, 0.1741696500898471362, 1e-12, "iauAtoc13", "H/dc", status);
    viv(j, 0, "iauAtoc13", "H/j", status);
 
    ob1 = 0.09233952224794989993;
@@ -1647,8 +1647,8 @@
    j = iauAtoc13 ( "A", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &rc, &dc);
-   vvd(rc, 2.709956744660731630, 1e-12, "iauAtoc13", "A/rc", status);
-   vvd(dc, 0.1741696500896438970, 1e-12, "iauAtoc13", "A/dc", status);
+   vvd(rc, 2.709956744659734086, 1e-12, "iauAtoc13", "A/rc", status);
+   vvd(dc, 0.1741696500898471366, 1e-12, "iauAtoc13", "A/dc", status);
    viv(j, 0, "iauAtoc13", "A/j", status);
 
 }
@@ -1666,7 +1666,7 @@
 **
 **  Called:  iauAtoi13, vvd, viv
 **
-**  This revision:  2013 October 3
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl,
@@ -1692,8 +1692,8 @@
    j = iauAtoi13 ( "R", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12, "iauAtoi13", "R/ri", status);
-   vvd(di, 0.1729371839114567725, 1e-12, "iauAtoi13", "R/di", status);
+   vvd(ri, 2.710121574447540810, 1e-12, "iauAtoi13", "R/ri", status);
+   vvd(di, 0.1729371839116608778, 1e-12, "iauAtoi13", "R/di", status);
    viv(j, 0, "iauAtoi13", "R/J", status);
 
    ob1 = -0.09247619879782006106;
@@ -1701,8 +1701,8 @@
    j = iauAtoi13 ( "H", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12, "iauAtoi13", "H/ri", status);
-   vvd(di, 0.1729371839114567725, 1e-12, "iauAtoi13", "H/di", status);
+   vvd(ri, 2.710121574448138676, 1e-12, "iauAtoi13", "H/ri", status);
+   vvd(di, 0.1729371839116608778, 1e-12, "iauAtoi13", "H/di", status);
    viv(j, 0, "iauAtoi13", "H/J", status);
 
    ob1 = 0.09233952224794989993;
@@ -1710,8 +1710,8 @@
    j = iauAtoi13 ( "A", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12, "iauAtoi13", "A/ri", status);
-   vvd(di, 0.1729371839114567728, 1e-12, "iauAtoi13", "A/di", status);
+   vvd(ri, 2.710121574448138676, 1e-12, "iauAtoi13", "A/ri", status);
+   vvd(di, 0.1729371839116608781, 1e-12, "iauAtoi13", "A/di", status);
    viv(j, 0, "iauAtoi13", "A/J", status);
 
 }
@@ -1729,7 +1729,7 @@
 *
 **  Called:  iauApio13, iauAtoiq, vvd
 *
-**  This revision:  2013 October 4
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl,
@@ -1755,25 +1755,25 @@
    ob1 = 2.710085107986886201;
    ob2 = 0.1717653435758265198;
    iauAtoiq("R", ob1, ob2, &astrom, &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12,
+   vvd(ri, 2.710121574447540810, 1e-12,
            "iauAtoiq", "R/ri", status);
-   vvd(di, 0.1729371839114567725, 1e-12,
+   vvd(di, 0.17293718391166087785, 1e-12,
            "iauAtoiq", "R/di", status);
 
    ob1 = -0.09247619879782006106;
    ob2 = 0.1717653435758265198;
    iauAtoiq("H", ob1, ob2, &astrom, &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12,
+   vvd(ri, 2.710121574448138676, 1e-12,
            "iauAtoiq", "H/ri", status);
-   vvd(di, 0.1729371839114567725, 1e-12,
+   vvd(di, 0.1729371839116608778, 1e-12,
            "iauAtoiq", "H/di", status);
 
    ob1 = 0.09233952224794989993;
    ob2 = 1.407758704513722461;
    iauAtoiq("A", ob1, ob2, &astrom, &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12,
+   vvd(ri, 2.710121574448138676, 1e-12,
            "iauAtoiq", "A/ri", status);
-   vvd(di, 0.1729371839114567728, 1e-12,
+   vvd(di, 0.1729371839116608781, 1e-12,
            "iauAtoiq", "A/di", status);
 
 }
@@ -3976,7 +3976,7 @@
 **
 **  Called:  iauFk52h, vvd
 **
-**  This revision:  2017 January 3
+**  This revision:  2021 January 5
 */
 {
    double r5, d5, dr5, dd5, px5, rv5, rh, dh, drh, ddh, pxh, rvh;
@@ -3996,7 +3996,7 @@
        "iauFk52h", "ra", status);
    vvd(dh,  -0.2917516070530391757, 1e-14,
        "iauFk52h", "dec", status);
-   vvd(drh, -0.19618741256057224e-6,1e-19,
+   vvd(drh, -0.1961874125605721270e-6,1e-19,
        "iauFk52h", "dr5", status);
    vvd(ddh, -0.58459905176693911e-5, 1e-19,
        "iauFk52h", "dd5", status);
@@ -7718,7 +7718,7 @@
 **
 **  Called:  iauPvu, vvd
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 January 5
 */
 {
    double pv[2][3], upv[2][3];
@@ -7734,11 +7734,11 @@
 
    iauPvu(2920.0, pv, upv);
 
-   vvd(upv[0][0], 126656.7598605317105, 1e-12,
+   vvd(upv[0][0], 126656.7598605317105, 1e-6,
        "iauPvu", "p1", status);
-   vvd(upv[0][1], 2118.531271155726332, 1e-12,
+   vvd(upv[0][1], 2118.531271155726332, 1e-8,
        "iauPvu", "p2", status);
-   vvd(upv[0][2], -245216.5048590656190, 1e-12,
+   vvd(upv[0][2], -245216.5048590656190, 1e-6,
        "iauPvu", "p3", status);
 
    vvd(upv[1][0], -0.4051854035740713039e-2, 1e-12,
@@ -7763,7 +7763,7 @@
 **
 **  Called:  iauPvup, vvd
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 January 5
 */
 {
    double pv[2][3], p[3];
@@ -7779,9 +7779,9 @@
 
    iauPvup(2920.0, pv, p);
 
-   vvd(p[0],  126656.7598605317105,   1e-12, "iauPvup", "1", status);
-   vvd(p[1],    2118.531271155726332, 1e-12, "iauPvup", "2", status);
-   vvd(p[2], -245216.5048590656190,   1e-12, "iauPvup", "3", status);
+   vvd(p[0],  126656.7598605317105,   1e-6, "iauPvup", "1", status);
+   vvd(p[1],    2118.531271155726332, 1e-8, "iauPvup", "2", status);
+   vvd(p[2], -245216.5048590656190,   1e-6, "iauPvup", "3", status);
 
 }
 
@@ -10157,7 +10157,7 @@
 }
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
+**  Copyright (C) 2021
 **  Standards Of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
```

</details> 

Depends on: #31